### PR TITLE
Fix contributors badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read about how this project started: <a href="https://eke.hashnode.dev/portfolio
 ## Contribute
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <div>Want to add a portfolio to this list? read the <a href="https://github.com/Evavic44/portfolio-ideas/blob/main/CONTRIBUTING.md">guidelines</a> on how to do that.</div>


### PR DESCRIPTION
This PR fixes a simple bug in the contributors badge in the README file. Before, clicking it wouldn`t jump to the contributors section, now it should work normally.
