### PR TITLE
Fix GitHub repository URL in config

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -10,7 +10,7 @@ export default {
       { text: "Guide", link: "/guide" },
       { text: "Contributors", link: "/contributors" },
     ],
-    socialLinks: [{ icon: "github", link: "https://github.com/evavic44" }],
+    socialLinks: [{ icon: "github", link: "https://github.com/Evavic44/portfolio-ideas" }],
     footer: {
       message: "Released under the MIT License.",
       copyright: "Copyright © 2022-present Victor Eke | Portfolio Ideas",


### PR DESCRIPTION
Fixes #617

Updated the GitHub icon URL in the VitePress config to point to the full repository URL instead of just the user profile.

Change: Updated `socialLinks` link from `https://github.com/evavic44` to `https://github.com/Evavic44/portfolio-ideas` in `docs/.vitepress/config.js`